### PR TITLE
Fix svox not allowing to complete repo sync

### DIFF
--- a/jb.xml
+++ b/jb.xml
@@ -170,7 +170,7 @@
   <project path="external/stlport" name="CyanogenMod/android_external_stlport" />
   <project path="external/strace" name="CyanogenMod/android_external_strace" />
   <project path="external/stressapptest" name="CyanogenMod/android_external_stressapptest" />
-  <project path="external/svox" name="CyanogenMod/android_external_svox" />
+  <project path="external/svox" name="platform/external/svox" remote="aosp" revision="refs/tags/android-4.1.2_r1" />
   <project path="external/tagsoup" name="CyanogenMod/android_external_tagsoup" />
   <project path="external/tcpdump" name="CyanogenMod/android_external_tcpdump" />
   <project path="external/tinyalsa" name="CyanogenMod/android_external_tinyalsa" />


### PR DESCRIPTION
Github got a DMCA takedown on this repo based on a licensing dispute with a former employee of SVOX

Taken from: https://github.com/CyanogenMod/android/commit/b0646722ea9c38578a2f6afff54b8fbc7c2d03c1

Signed-off-by: Juan Martin Runge jmrunge@gmail.com
